### PR TITLE
Refactor New Relic Interceptors to Use finalize for Reliable Transaction Cleanup

### DIFF
--- a/child/src/newrelic.interceptor.ts
+++ b/child/src/newrelic.interceptor.ts
@@ -5,7 +5,7 @@ import {
   CallHandler,
 } from '@nestjs/common';
 import { Observable } from 'rxjs';
-import { tap } from 'rxjs/operators';
+import { finalize } from 'rxjs/operators';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const util = require('util');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -17,17 +17,18 @@ export class NewrelicInterceptor implements NestInterceptor {
     console.log(
       `Child Interceptor before: ${util.inspect(context.getHandler().name)}`,
     );
+
     return newrelic.startWebTransaction(context.getHandler().name, function () {
       const transaction = newrelic.getTransaction();
-      // const now = Date.now();
+
       return next.handle().pipe(
-        tap(() => {
+        finalize(() => {
           console.log(
-            `Child Interceptor after: ${util.inspect(
+            `Child Interceptor finalized: ${util.inspect(
               context.getHandler().name,
             )}`,
           );
-          return transaction.end();
+          transaction.end();
         }),
       );
     });

--- a/parent/src/newrelic.interceptor.ts
+++ b/parent/src/newrelic.interceptor.ts
@@ -5,7 +5,7 @@ import {
   CallHandler,
 } from '@nestjs/common';
 import { Observable } from 'rxjs';
-import { tap } from 'rxjs/operators';
+import { finalize } from 'rxjs/operators';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const util = require('util');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -17,17 +17,18 @@ export class NewrelicInterceptor implements NestInterceptor {
     console.log(
       `Parent Interceptor before: ${util.inspect(context.getHandler().name)}`,
     );
+
     return newrelic.startWebTransaction(context.getHandler().name, function () {
       const transaction = newrelic.getTransaction();
-      // const now = Date.now();
+
       return next.handle().pipe(
-        tap(() => {
+        finalize(() => {
           console.log(
-            `Parent Interceptor after: ${util.inspect(
+            `Parent Interceptor finalized: ${util.inspect(
               context.getHandler().name,
             )}`,
           );
-          return transaction.end();
+          transaction.end();
         }),
       );
     });


### PR DESCRIPTION
This PR updates both the Parent and Child NewrelicInterceptor classes to replace `tap()` with `finalize()` in their RxJS pipelines.

The original implementation used `tap()` to end the New Relic transaction after successful execution of the request handler. However, `tap()` does not guarantee execution when an observable errors or is unsubscribed (e.g., due to client disconnect or internal failure). This could lead to unfinished transactions in New Relic, skewing metrics and leaving orphaned traces.

The Fix
	•	Replaced `tap()` with `finalize()` to ensure `transaction.end()` is always invoked:
	•	On success
	•	On error
	•	On cancellation/unsubscribe
	•	Updated log messages to reflect the use of finalization ("Interceptor finalized")

Benefits
	•	Ensures reliable transaction termination in all execution paths
	•	Prevents incomplete or hanging transactions in New Relic
	•	Improves observability and metric accuracy in production
