### PR TITLE
Updated default logging level from trace to info in newrelic.ts file

### DIFF
--- a/child/src/newrelic.ts
+++ b/child/src/newrelic.ts
@@ -36,7 +36,7 @@ exports.config = {
      * issues with the agent, 'info' and higher will impose the least overhead on
      * production applications.
      */
-    level: 'trace',
+    level: 'info',
   },
   /**
    * When true, all request headers except for those listed in attributes.exclude

--- a/parent/src/newrelic.ts
+++ b/parent/src/newrelic.ts
@@ -36,7 +36,7 @@ exports.config = {
      * issues with the agent, 'info' and higher will impose the least overhead on
      * production applications.
      */
-    level: 'trace',
+    level: 'info',
   },
   /**
    * When true, all request headers except for those listed in attributes.exclude


### PR DESCRIPTION
### What this PR contains:
- [ ] Updated the logging level in newrelic.ts file in both child and parent src.
- [ ] This is done in order to save the high disk usage if someone uses this newrelic strategy in production.
- [ ] I had my production kubernetes cluster nodes crashed as my apps were collection alot of trace level logs which was not getting flushed properly in time by the new relic agent.