### PR TITLE
fix: change default New Relic log level from trace to info

### DIFF
--- a/child/src/newrelic.ts
+++ b/child/src/newrelic.ts
@@ -36,7 +36,7 @@ exports.config = {
      * issues with the agent, 'info' and higher will impose the least overhead on
      * production applications.
      */
-    level: 'trace',
+    level: 'info',
   },
   /**
    * When true, all request headers except for those listed in attributes.exclude

--- a/parent/src/newrelic.ts
+++ b/parent/src/newrelic.ts
@@ -36,7 +36,7 @@ exports.config = {
      * issues with the agent, 'info' and higher will impose the least overhead on
      * production applications.
      */
-    level: 'trace',
+    level: 'info',
   },
   /**
    * When true, all request headers except for those listed in attributes.exclude


### PR DESCRIPTION
## Summary
- Changes default New Relic log level from `trace` to `info` in both `parent` and `child` configs

## Context
This change was originally proposed in #20 but the contributor had not signed the CLA, so we are applying it directly. Credit to @SujalKokh for the suggestion.

`trace` logging in production can generate excessive disk I/O that the New Relic agent doesn't flush fast enough, causing node pressure on Kubernetes clusters. The `newrelic.ts` config file itself already documents that `info` and higher impose the least overhead on production applications.

## Test plan
- [ ] Verify New Relic agent starts without errors with `level: 'info'`
- [ ] Confirm log volume is reduced in a production-like environment